### PR TITLE
Revamp GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 - 🧠 Currently diving deep into machine learning fundamentals and experimenting with large language models for smarter tooling.
 - 🛠️ Love designing clean REST/gRPC APIs, background workers, and data-intensive pipelines.
 - 📈 Always hunting for performance wins—profiling queries, taming queues, and squeezing extra throughput out of infrastructure.
-- 🤝 Happy to collaborate on open-source projects, especially around automation, AI-assisted dev tools, and observability.
 
 ## 📊 GitHub Snapshot
 
@@ -38,9 +37,9 @@
 
 ## 🧪 What I'm Experimenting With
 
-- Building lightweight evaluation harnesses to benchmark LLM responses for code-generation and review tasks.
-- Mixing vector databases with traditional search to deliver context-aware assistants.
-- Documenting findings through gists and repos so others can reproduce and iterate.
+- Prototyping personal LLM pipelines—trying different open-source and hosted models to streamline daily tasks (like the interview-debrief analyzer I built for myself).
+- Exploring retrieval-augmented setups along with text2SQL, text2text, and audio2text models to boost research and automation workflows.
+- Capturing what works (and what doesn't) so future me—and anyone following along—can reuse the best setups.
 
 ## 🔗 Find Me Around the Web
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,43 @@
-### Hi there, I'm Qu1ck1337 👋
-![Qu1ck1337's GitHub stats](https://github-readme-stats.vercel.app/api?username=Qu1ck1337&show_icons=true&theme=tokyonight)
-
-# Languages / Tools
-<div >
-	<img src="https://skillicons.dev/icons?i=python,django,fastapi,html,css,js,react,cs,mongodb,postgresql,git,docker,linux,rabbitmq,kafka,postman" />
+<div align="center">
+  <h1>Hi there, I'm Qu1ck1337 👋</h1>
+  <p>Building reliable back-end services and delightful front-end experiences.</p>
+  <a href="https://komarev.com/ghpvc/?username=Qu1ck1337">
+    <img src="https://komarev.com/ghpvc/?username=Qu1ck1337&style=flat-square&color=blueviolet" alt="Profile views" />
+  </a>
 </div>
 
-# Links
+---
+
+## 🚀 Quick Facts
+
+- 💡 Back-end leaning developer who enjoys crafting RESTful APIs, automation scripts, and interactive dashboards.
+- 🧠 Algorithm enthusiast constantly sharpening problem-solving skills on LeetCode.
+- 🤝 Open to collaborating on open-source tooling, developer productivity, or data-intensive projects.
+- 📬 Reach out through issues or discussions—always happy to connect.
+
+## 📊 GitHub Snapshot
+
+| <img src="https://github-readme-stats.vercel.app/api?username=Qu1ck1337&show_icons=true&theme=tokyonight&hide_border=true" alt="GitHub stats" /> | <img src="https://streak-stats.demolab.com?user=Qu1ck1337&theme=tokyonight&hide_border=true" alt="GitHub streak" /> |
+| --- | --- |
+| <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Qu1ck1337&layout=compact&theme=tokyonight&hide_border=true" alt="Top languages" /> | <img src="https://github-profile-trophy.vercel.app/?username=Qu1ck1337&theme=tokyonight&no-frame=true&column=3&margin-w=15&margin-h=15" alt="GitHub trophies" /> |
+
+## 🧰 Tech Toolbox
+
+<div align="center">
+  <img src="https://skillicons.dev/icons?i=python,django,fastapi,html,css,js,react,cs,mongodb,postgresql,git,docker,linux,rabbitmq,kafka,postman&perline=8" alt="Tech stack" />
+</div>
+
+## 🌱 Currently Exploring
+
+- Scaling asynchronous services with message queues like RabbitMQ and Kafka.
+- Enhancing front-end experiences with modern React tooling.
+- Sharing knowledge via write-ups, gists, and code reviews.
+
+## 🔗 Find Me Around the Web
+
 - ✨ [LeetCode](https://leetcode.com/u/Qu1ck_1337/)
+- 💬 Open an issue or discussion on any repository to start a conversation.
+
 <!--
 **Qu1ck1337/Qu1ck1337** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@
   <table>
     <tr>
       <th>Backend &amp; Data</th>
-      <th>ML &amp; Frontend</th>
+      <th>Machine Learning</th>
+      <th>Frontend</th>
       <th>Cloud &amp; Automation</th>
     </tr>
     <tr>
@@ -41,7 +42,10 @@
         <img src="https://skillicons.dev/icons?i=python,fastapi,django,postgresql,redis,mongodb,sqlite,git,docker,linux&amp;perline=5" alt="Backend and data toolkit" />
       </td>
       <td align="center" style="padding: 8px 16px;">
-        <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv,react,js,ts,html,css,bootstrap&amp;perline=5" alt="ML and frontend toolkit" />
+        <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv&amp;perline=4" alt="Machine learning toolkit" />
+      </td>
+      <td align="center" style="padding: 8px 16px;">
+        <img src="https://skillicons.dev/icons?i=react,js,ts,html,css,bootstrap&amp;perline=6" alt="Frontend toolkit" />
       </td>
       <td align="center" style="padding: 8px 16px;">
         <img src="https://skillicons.dev/icons?i=gcp,githubactions,jenkins,bash&amp;perline=4" alt="Cloud and automation toolkit" />

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 🧠 Currently diving deep into machine learning fundamentals and experimenting with large language models for smarter tooling.
 - 🛠️ Love designing clean REST/gRPC APIs, background workers, and data-intensive pipelines.
 - 📈 Always hunting for performance wins—profiling queries, taming queues, and squeezing extra throughput out of infrastructure.
+- 🔁 Shipping pragmatic CI/CD with GitHub Actions and Jenkins, plus containerizing services with Docker on GCP.
 
 ## 📊 GitHub Snapshot
 
@@ -30,9 +31,9 @@
 ## 🧰 Toolbox
 
 <div align="center">
-  <img src="https://skillicons.dev/icons?i=python,fastapi,django,flask,postgresql,redis,mongodb,sqlite,git,docker,linux&perline=5" alt="Back-end stack" />
+  <img src="https://skillicons.dev/icons?i=python,fastapi,django,postgresql,redis,mongodb,sqlite,git,docker,linux&perline=5" alt="Back-end stack" />
   <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv,react,js,ts,html,css,bootstrap&perline=5" alt="ML and front-end toolkit" />
-  <img src="https://skillicons.dev/icons?i=aws,gcp,bash,powershell,githubactions&perline=5" alt="Cloud and automation" />
+  <img src="https://skillicons.dev/icons?i=gcp,githubactions,jenkins,bash&perline=4" alt="Cloud and automation" />
 </div>
 
 ## 🧪 What I'm Experimenting With

--- a/README.md
+++ b/README.md
@@ -31,9 +31,45 @@
 ## 🧰 Toolbox
 
 <div align="center">
-  <img src="https://skillicons.dev/icons?i=python,fastapi,django,postgresql,redis,mongodb,sqlite,git,docker,linux&perline=5" alt="Back-end stack" />
-  <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv,react,js,ts,html,css,bootstrap&perline=5" alt="ML and front-end toolkit" />
-  <img src="https://skillicons.dev/icons?i=gcp,githubactions,jenkins,bash&perline=4" alt="Cloud and automation" />
+  <table>
+    <tr>
+      <th>Backend &amp; Data</th>
+      <th>ML &amp; Frontend</th>
+      <th>Cloud &amp; Automation</th>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 8px 16px;">
+        <img src="https://skillicons.dev/icons?i=python" alt="Python" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=fastapi" alt="FastAPI" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=django" alt="Django" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=postgresql" alt="PostgreSQL" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=redis" alt="Redis" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=mongodb" alt="MongoDB" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=sqlite" alt="SQLite" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=git" alt="Git" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=docker" alt="Docker" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=linux" alt="Linux" height="48" style="margin: 6px;" />
+      </td>
+      <td align="center" style="padding: 8px 16px;">
+        <img src="https://skillicons.dev/icons?i=pytorch" alt="PyTorch" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=tensorflow" alt="TensorFlow" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=sklearn" alt="scikit-learn" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=opencv" alt="OpenCV" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=react" alt="React" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=js" alt="JavaScript" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=ts" alt="TypeScript" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=html" alt="HTML" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=css" alt="CSS" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=bootstrap" alt="Bootstrap" height="48" style="margin: 6px;" />
+      </td>
+      <td align="center" style="padding: 8px 16px;">
+        <img src="https://skillicons.dev/icons?i=gcp" alt="Google Cloud" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=githubactions" alt="GitHub Actions" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=jenkins" alt="Jenkins" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=bash" alt="Bash" height="48" style="margin: 6px;" />
+      </td>
+    </tr>
+  </table>
 </div>
 
 ## 🧪 What I'm Experimenting With

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 
 - 🧠 Currently diving deep into machine learning fundamentals and experimenting with large language models for smarter tooling.
 - 🛠️ Love designing clean REST/gRPC APIs, background workers, and data-intensive pipelines.
-- 📈 Always hunting for performance wins—profiling queries, taming queues, and squeezing extra throughput out of infrastructure.
 - 🔁 Shipping pragmatic CI/CD with GitHub Actions and Jenkins, plus hands-on time with Docker and GCP.
 
 ## 📊 GitHub Snapshot
@@ -39,34 +38,13 @@
     </tr>
     <tr>
       <td align="center" style="padding: 8px 16px;">
-        <img src="https://skillicons.dev/icons?i=python" alt="Python" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=fastapi" alt="FastAPI" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=django" alt="Django" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=postgresql" alt="PostgreSQL" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=redis" alt="Redis" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=mongodb" alt="MongoDB" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=sqlite" alt="SQLite" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=git" alt="Git" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=docker" alt="Docker" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=linux" alt="Linux" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=python,fastapi,django,postgresql,redis,mongodb,sqlite,git,docker,linux&amp;perline=5" alt="Backend and data toolkit" />
       </td>
       <td align="center" style="padding: 8px 16px;">
-        <img src="https://skillicons.dev/icons?i=pytorch" alt="PyTorch" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=tensorflow" alt="TensorFlow" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=sklearn" alt="scikit-learn" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=opencv" alt="OpenCV" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=react" alt="React" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=js" alt="JavaScript" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=ts" alt="TypeScript" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=html" alt="HTML" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=css" alt="CSS" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=bootstrap" alt="Bootstrap" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv,react,js,ts,html,css,bootstrap&amp;perline=5" alt="ML and frontend toolkit" />
       </td>
       <td align="center" style="padding: 8px 16px;">
-        <img src="https://skillicons.dev/icons?i=gcp" alt="Google Cloud" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=githubactions" alt="GitHub Actions" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=jenkins" alt="Jenkins" height="48" style="margin: 6px;" />
-        <img src="https://skillicons.dev/icons?i=bash" alt="Bash" height="48" style="margin: 6px;" />
+        <img src="https://skillicons.dev/icons?i=gcp,githubactions,jenkins,bash&amp;perline=4" alt="Cloud and automation toolkit" />
       </td>
     </tr>
   </table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
-  <h1>Hi there, I'm Qu1ck1337 👋</h1>
-  <p>Building reliable back-end services and delightful front-end experiences.</p>
+  <h1>Hey, I'm Qu1ck1337 👋</h1>
+  <p>Backend-focused developer tinkering with machine learning and AI-assisted tooling.</p>
+  <p>I enjoy shipping reliable services, automating workflows, and leveling up developer experience.</p>
   <a href="https://komarev.com/ghpvc/?username=Qu1ck1337">
     <img src="https://komarev.com/ghpvc/?username=Qu1ck1337&style=flat-square&color=blueviolet" alt="Profile views" />
   </a>
@@ -8,12 +9,12 @@
 
 ---
 
-## 🚀 Quick Facts
+## 🧾 TL;DR
 
-- 💡 Back-end leaning developer who enjoys crafting RESTful APIs, automation scripts, and interactive dashboards.
-- 🧠 Algorithm enthusiast constantly sharpening problem-solving skills on LeetCode.
-- 🤝 Open to collaborating on open-source tooling, developer productivity, or data-intensive projects.
-- 📬 Reach out through issues or discussions—always happy to connect.
+- 🧠 Currently diving deep into machine learning fundamentals and experimenting with large language models for smarter tooling.
+- 🛠️ Love designing clean REST/gRPC APIs, background workers, and data-intensive pipelines.
+- 📈 Always hunting for performance wins—profiling queries, taming queues, and squeezing extra throughput out of infrastructure.
+- 🤝 Happy to collaborate on open-source projects, especially around automation, AI-assisted dev tools, and observability.
 
 ## 📊 GitHub Snapshot
 
@@ -21,17 +22,25 @@
 | --- | --- |
 | <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Qu1ck1337&layout=compact&theme=tokyonight&hide_border=true" alt="Top languages" /> | <img src="https://github-profile-trophy.vercel.app/?username=Qu1ck1337&theme=tokyonight&no-frame=true&column=3&margin-w=15&margin-h=15" alt="GitHub trophies" /> |
 
-## 🧰 Tech Toolbox
+## 🧠 Focus & Learning
+
+- **ML Foundations:** sharpening math intuition, building data workflows, and training/evaluating models end-to-end.
+- **LLM Playground:** running open-source LLMs locally, comparing inference strategies, and crafting prompts/agents that are genuinely helpful.
+- **Service Engineering:** evolving resilient microservices, async processing, and telemetry-rich observability stacks.
+
+## 🧰 Toolbox
 
 <div align="center">
-  <img src="https://skillicons.dev/icons?i=python,django,fastapi,html,css,js,react,cs,mongodb,postgresql,git,docker,linux,rabbitmq,kafka,postman&perline=8" alt="Tech stack" />
+  <img src="https://skillicons.dev/icons?i=python,fastapi,django,flask,postgresql,redis,mongodb,sqlite,git,docker,linux&perline=5" alt="Back-end stack" />
+  <img src="https://skillicons.dev/icons?i=pytorch,tensorflow,sklearn,opencv,react,js,ts,html,css,bootstrap&perline=5" alt="ML and front-end toolkit" />
+  <img src="https://skillicons.dev/icons?i=aws,gcp,bash,powershell,githubactions&perline=5" alt="Cloud and automation" />
 </div>
 
-## 🌱 Currently Exploring
+## 🧪 What I'm Experimenting With
 
-- Scaling asynchronous services with message queues like RabbitMQ and Kafka.
-- Enhancing front-end experiences with modern React tooling.
-- Sharing knowledge via write-ups, gists, and code reviews.
+- Building lightweight evaluation harnesses to benchmark LLM responses for code-generation and review tasks.
+- Mixing vector databases with traditional search to deliver context-aware assistants.
+- Documenting findings through gists and repos so others can reproduce and iterate.
 
 ## 🔗 Find Me Around the Web
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 🧠 Currently diving deep into machine learning fundamentals and experimenting with large language models for smarter tooling.
 - 🛠️ Love designing clean REST/gRPC APIs, background workers, and data-intensive pipelines.
 - 📈 Always hunting for performance wins—profiling queries, taming queues, and squeezing extra throughput out of infrastructure.
-- 🔁 Shipping pragmatic CI/CD with GitHub Actions and Jenkins, plus containerizing services with Docker on GCP.
+- 🔁 Shipping pragmatic CI/CD with GitHub Actions and Jenkins, plus hands-on time with Docker and GCP.
 
 ## 📊 GitHub Snapshot
 


### PR DESCRIPTION
## Summary
- refresh the hero section with a profile view badge and quick highlights
- add a GitHub snapshot table featuring stats, streak, top languages, and trophies
- expand toolbox, learning focus, and link sections for a richer profile overview

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf0183c860832195ea7e040d7a0765